### PR TITLE
Add experimental macOS Qt 6 port and packaging support

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,32 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install cmake ninja qt taglib ffmpeg yt-dlp quickjs pkg-config
+
+      - name: Build and package
+        run: |
+          QT_PREFIX="$(brew --prefix qt)" BUILD_DIR="$PWD/build" scripts/package-macos.sh
+
+      - name: Upload app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SpotifyDownloader-macOS
+          path: build/SpotifyDownloader.app
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ Makefile*
 *build-*
 *.qm
 *.prl
+*.app
+.DS_Store
 
 # Qt unit tests
 target_wrapper.*
@@ -74,6 +76,7 @@ saves/
 mono_crash.*
 
 # Build results
+[Bb]uild*/
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,11 @@
+brew "taglib"
+brew "ffmpeg"
+brew "yt-dlp"
+brew "quickjs"
+brew "cmake"
+brew "ninja"
+brew "qt"
+brew "pkg-config"
+
+# The canonical macOS development path is Qt 6 + CMake.
+# The qmake project remains useful for local compatibility experiments.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,149 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(SpotifyDownloader VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+if(APPLE)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS deployment version")
+endif()
+
+find_package(Qt6 REQUIRED COMPONENTS
+    Core
+    Gui
+    Network
+    Widgets
+    WebEngineCore
+    WebEngineWidgets
+    Concurrent
+)
+
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+    pkg_check_modules(TAGLIB IMPORTED_TARGET taglib)
+endif()
+
+if(NOT TARGET PkgConfig::TAGLIB)
+    find_program(TAGLIB_CONFIG_EXECUTABLE taglib-config)
+    if(NOT TAGLIB_CONFIG_EXECUTABLE AND EXISTS "/usr/local/opt/taglib/bin/taglib-config")
+        set(TAGLIB_CONFIG_EXECUTABLE "/usr/local/opt/taglib/bin/taglib-config")
+    endif()
+
+    if(NOT TAGLIB_CONFIG_EXECUTABLE)
+        message(FATAL_ERROR "TagLib was not found. Install TagLib or set taglib-config on PATH.")
+    endif()
+
+    execute_process(
+        COMMAND "${TAGLIB_CONFIG_EXECUTABLE}" --cflags
+        OUTPUT_VARIABLE TAGLIB_CFLAGS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(
+        COMMAND "${TAGLIB_CONFIG_EXECUTABLE}" --libs
+        OUTPUT_VARIABLE TAGLIB_LIBS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+
+    separate_arguments(TAGLIB_CFLAGS_LIST UNIX_COMMAND "${TAGLIB_CFLAGS}")
+    separate_arguments(TAGLIB_LIBS_LIST UNIX_COMMAND "${TAGLIB_LIBS}")
+
+    add_library(TagLib::TagLib INTERFACE IMPORTED)
+    target_compile_options(TagLib::TagLib INTERFACE ${TAGLIB_CFLAGS_LIST})
+    target_link_options(TagLib::TagLib INTERFACE ${TAGLIB_LIBS_LIST})
+endif()
+
+set(APP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Spotify Downloader")
+
+set(SPOTIFY_DOWNLOADER_SOURCES
+    "${APP_DIR}/main.cpp"
+    "${APP_DIR}/Application.cpp"
+    "${APP_DIR}/Config.cpp"
+    "${APP_DIR}/SpotifyDownloader.cpp"
+    "${APP_DIR}/Downloading/PlaylistDownloader.cpp"
+    "${APP_DIR}/Downloading/Song.cpp"
+    "${APP_DIR}/Downloading/SongDownloader.cpp"
+    "${APP_DIR}/Lyrics/LRCFile.cpp"
+    "${APP_DIR}/Lyrics/Lyrics.cpp"
+    "${APP_DIR}/Network/MusixmatchAPI.cpp"
+    "${APP_DIR}/Network/Network.cpp"
+    "${APP_DIR}/Network/Notices.cpp"
+    "${APP_DIR}/Network/SpotifyAPI.cpp"
+    "${APP_DIR}/Network/SpotifyAuthInterceptor.cpp"
+    "${APP_DIR}/Network/SpotifyAuthRetriever.cpp"
+    "${APP_DIR}/Network/VersionManager.cpp"
+    "${APP_DIR}/Network/YTMusicAPI.cpp"
+    "${APP_DIR}/Playlist/M3UFile.cpp"
+    "${APP_DIR}/Playlist/PLSFile.cpp"
+    "${APP_DIR}/Playlist/PlaylistFile.cpp"
+    "${APP_DIR}/Playlist/XSPFFile.cpp"
+    "${APP_DIR}/UI/UISetup.cpp"
+    "${APP_DIR}/UI/UIUtilities.cpp"
+    "${APP_DIR}/UI/CustomWidgets/CheckBox.cpp"
+    "${APP_DIR}/UI/CustomWidgets/DownloaderThread.cpp"
+    "${APP_DIR}/UI/CustomWidgets/NoticeItem.cpp"
+    "${APP_DIR}/UI/CustomWidgets/SongErrorItem.cpp"
+    "${APP_DIR}/Utilities/Animation.cpp"
+    "${APP_DIR}/Utilities/FileUtils.cpp"
+    "${APP_DIR}/Utilities/ImageUtils.cpp"
+    "${APP_DIR}/Utilities/JSONUtils.cpp"
+    "${APP_DIR}/Utilities/Logger.cpp"
+    "${APP_DIR}/Utilities/MathUtils.cpp"
+    "${APP_DIR}/Utilities/ObjectHoverWatcher.cpp"
+    "${APP_DIR}/Utilities/StringUtils.cpp"
+    "${APP_DIR}/SpotifyDownloader.ui"
+    "${APP_DIR}/SpotifyDownloader.qrc"
+)
+
+if(WIN32)
+    list(APPEND SPOTIFY_DOWNLOADER_SOURCES "${APP_DIR}/SpotifyDownloader.rc")
+endif()
+
+qt_add_executable(SpotifyDownloader
+    MACOSX_BUNDLE
+    WIN32
+    ${SPOTIFY_DOWNLOADER_SOURCES}
+)
+
+target_include_directories(SpotifyDownloader PRIVATE
+    "${APP_DIR}"
+    "${APP_DIR}/include"
+)
+
+target_link_libraries(SpotifyDownloader PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Network
+    Qt6::Widgets
+    Qt6::WebEngineCore
+    Qt6::WebEngineWidgets
+    Qt6::Concurrent
+)
+
+if(TARGET PkgConfig::TAGLIB)
+    target_link_libraries(SpotifyDownloader PRIVATE PkgConfig::TAGLIB)
+else()
+    target_link_libraries(SpotifyDownloader PRIVATE TagLib::TagLib)
+endif()
+
+if(APPLE)
+    set_target_properties(SpotifyDownloader PROPERTIES
+        OUTPUT_NAME "SpotifyDownloader"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.williamschack.spotifydownloader"
+        MACOSX_BUNDLE_BUNDLE_NAME "Spotify Downloader"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+    )
+endif()
+
+install(TARGETS SpotifyDownloader
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION bin
+)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 <img src="https://github.com/ChazzBurger/Spotify-Downloader/assets/54973797/0998c0ca-bc59-4cb4-a9f5-76956d3bbe27" align="right" style="height: 6%; width: 6%;">
 
 # Spotify Downloader
-[![Latest Release](https://img.shields.io/github/v/release/WilliamSchack/Spotify-Downloader?label=Latest%20Release&color=007ec6)](https://github.com/ChazzBurger/Spotify-Downloader/releases)
-[![Downloads](https://img.shields.io/github/downloads/WilliamSchack/Spotify-Downloader/total?label=Downloads&color=007ec6)](https://github.com/ChazzBurger/Spotify-Downloader/releases)
-[![Open Issues](https://img.shields.io/github/issues/WilliamSchack/Spotify-Downloader?label=Issues)](https://github.com/ChazzBurger/Spotify-Downloader/issues?q=is%3Aissue+is%3Aopen)
-[![Closed Issues](https://img.shields.io/github/issues-closed/WilliamSchack/Spotify-Downloader?label=Issues)](https://github.com/ChazzBurger/Spotify-Downloader/issues?q=is%3Aissue+is%3Aclosed)
-[![Stars](https://img.shields.io/github/stars/WilliamSchack/Spotify-Downloader?label=Stars&color=007ec6)](https://github.com/ChazzBurger/Spotify-Downloader/stargazers)
+[![Latest Release](https://img.shields.io/github/v/release/garylee909/Spotify-Downloader?label=Latest%20Release&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/releases)
+[![Downloads](https://img.shields.io/github/downloads/garylee909/Spotify-Downloader/total?label=Downloads&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/releases)
+[![Open Issues](https://img.shields.io/github/issues/garylee909/Spotify-Downloader?label=Issues)](https://github.com/garylee909/Spotify-Downloader/issues?q=is%3Aissue+is%3Aopen)
+[![Closed Issues](https://img.shields.io/github/issues-closed/garylee909/Spotify-Downloader?label=Issues)](https://github.com/garylee909/Spotify-Downloader/issues?q=is%3Aissue+is%3Aclosed)
+[![Stars](https://img.shields.io/github/stars/garylee909/Spotify-Downloader?label=Stars&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/stargazers)
 [![Ko-Fi](https://img.shields.io/badge/Support%20Development-FF5a16?style=flat&logo=Ko-fi&logoColor=FF5a16&label=ko-fi)](https://ko-fi.com/williamschack)
 
 Spotify Downloader is an application that allows you to easily download spotify playlists and songs through YouTube without the need of Spotify Premium through an easy to use GUI and many customisable settings to get the output that you desire.
+
+> [!IMPORTANT]
+> This repository contains an unofficial macOS port of
+> [WilliamSchack/Spotify-Downloader](https://github.com/WilliamSchack/Spotify-Downloader).
+> The macOS build is currently an Intel (`x86_64`) preview and is not signed
+> with an Apple Developer ID or notarized by Apple.
 
 > [!CAUTION]
 > Note that users are responsible for any potential legal consequenses that comes with downloading music. I do not condone unauthorized downloading of copyrighted material and do not take any responsibility for user actions. I highly encourage you to purchase the songs directly from the artists to support them and their work
@@ -20,6 +26,8 @@ Spotify Downloader is an application that allows you to easily download spotify 
 
 ## Contents
 - [Installation](#installation)
+  - [macOS](#macos)
+  - [Windows](#windows)
 - [Usage](#usage)
 - [Features](#features)
 - [Roadmap](#roadmap)
@@ -28,9 +36,57 @@ Spotify Downloader is an application that allows you to easily download spotify 
 - [Credits](#credits)
 
 ## Installation
-***Only currently supports windows. Other platforms may be coming soon***
 
-The latest release can be found [Here](https://github.com/WilliamSchack/Spotify-Downloader/releases/latest). **For multiple use Installer Recommended, for single use Portable Recommended**
+### macOS
+
+> [!WARNING]
+> The current preview build targets Intel Macs running macOS 26 or later.
+> Apple Silicon Macs require Rosetta 2. Wider macOS compatibility and a native
+> Apple Silicon build are not included in the current DMG.
+
+1. Open this repository's [Releases](https://github.com/garylee909/Spotify-Downloader/releases).
+2. Download `SpotifyDownloader-macOS.dmg` from the latest macOS release.
+3. Open the DMG and copy `SpotifyDownloader.app` to the `Applications` folder.
+4. Eject the DMG, then open Spotify Downloader from `Applications`.
+
+The app includes `ffmpeg`, `yt-dlp`, and QuickJS. Users installing the DMG do
+not need Homebrew, Anaconda, Qt, or a separate Python installation.
+
+#### First launch
+
+The preview is ad-hoc signed but not notarized. macOS may prevent a normal
+double-click launch:
+
+1. In Finder, open `Applications`.
+2. Control-click or right-click `SpotifyDownloader.app`, then select **Open**.
+3. Select **Open** again in the confirmation dialog.
+4. If **Open** is not offered, go to **System Settings > Privacy & Security**,
+   find the blocked Spotify Downloader message, and select **Open Anyway**.
+
+Only use a DMG downloaded from this repository's Releases page. A future
+Developer ID signed and notarized release will remove this extra first-launch
+step.
+
+#### Apple Silicon
+
+When prompted, allow macOS to install Rosetta 2. It can also be installed from
+Terminal:
+
+```sh
+softwareupdate --install-rosetta
+```
+
+Rosetta is an Apple compatibility component. It is only needed because the
+current preview is an Intel build.
+
+### Windows
+
+The Windows packages and instructions below are maintained by the
+[upstream project](https://github.com/WilliamSchack/Spotify-Downloader).
+
+The latest upstream Windows release can be found
+[here](https://github.com/WilliamSchack/Spotify-Downloader/releases/latest).
+**For multiple use Installer Recommended, for single use Portable Recommended**
 
 Follow the instructions below depending on your chosen install type.
 
@@ -113,6 +169,19 @@ This has been fixed and the app has been excluded from windows defender scans, i
 
 > [!WARNING]
 > Please note that downloading too many songs in a short time span can lead to YouTube flagging your IP and preventing further downloads (Will not effect your YouTube experience). I have not experienced it personally and have downloaded a few thousand songs within a day on a few occasions when testing but there is a case where someone downloaded 5000 songs in one day which got their IP flagged so if you intend to download a large amount of songs it is safer to spread it out over a few days or limit your download speed in the settings.
+
+### Quick Start
+
+1. Open Spotify and copy the link for a public song, album, or playlist using
+   **Share > Copy link**.
+2. Open Spotify Downloader and paste the link into **Enter Song/Playlist URL**.
+3. Select a save location.
+4. Review the output format and other options in **Settings**.
+5. Start the download and wait for processing to finish.
+
+Spotify Premium is not required. YouTube cookies and custom Spotify API keys
+are optional and should only be configured when the related advanced features
+are needed.
 
 ### User Interface
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Spotify Downloader is an application that allows you to easily download spotify 
 - [Usage](#usage)
 - [Features](#features)
 - [Roadmap](#roadmap)
+- [Contributing](#contributing)
 - [License](#license)
 - [FAQ](#faq)
 - [Credits](#credits)
@@ -724,6 +725,24 @@ The next few updates will take a fair amount of work and time so figured I would
    - There are a few features that are poorly implemented and could be much better so I for those I want to go through a proper process to implement them
    - From v2.0.0 I will start properly planning out features and I will re-do some that are currently implemented to make them better to use
 
+## Contributing
+
+Contributions to the macOS port are welcome.
+
+1. Fork this repository and create a branch from `macos-port`.
+2. Follow the setup and build instructions in
+   [`docs/MACOS.md`](docs/MACOS.md).
+3. Keep generated files out of Git. Do not commit `build/`, `*.app`, `*.dmg`,
+   `Makefile`, object files, or generated Qt files.
+4. Build and test the app before opening a pull request.
+5. Open the pull request against this repository's `macos-port` branch and
+   include the Mac model, CPU architecture, macOS version, and test results.
+
+Changes that are not specific to the macOS port may be better contributed to
+the [upstream project](https://github.com/WilliamSchack/Spotify-Downloader).
+Please explain any cross-platform behavior changes clearly so they can be
+reviewed without breaking the upstream Windows build.
+
 ## License
 ***Spotify Downloader is distributed under the GNU General Public License v3.0 from 17/04/2024 and Release v1.1.3***
 
@@ -780,6 +799,14 @@ When I first created this project I has a lot of free time on my hands and was a
 </details>
 
 ## Credits
+
+**Project**
+
+- Original Spotify Downloader application by
+  [William Schack](https://github.com/WilliamSchack).
+- macOS port by [Gary Lee](https://github.com/garylee909), developed in
+  collaboration with OpenAI Codex.
+
 **Packages Used**
 - [Qt](https://www.qt.io/) - [LGPL v3 License](https://doc.qt.io/qt-6/lgpl.html)
 - [Python YT Music API](https://github.com/sigma67/ytmusicapi) - [MIT License](https://github.com/sigma67/ytmusicapi/blob/main/LICENSE) (Translated to C++)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 <img src="https://github.com/ChazzBurger/Spotify-Downloader/assets/54973797/0998c0ca-bc59-4cb4-a9f5-76956d3bbe27" align="right" style="height: 6%; width: 6%;">
 
 # Spotify Downloader
-[![Latest Release](https://img.shields.io/github/v/release/garylee909/Spotify-Downloader?label=Latest%20Release&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/releases)
-[![Downloads](https://img.shields.io/github/downloads/garylee909/Spotify-Downloader/total?label=Downloads&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/releases)
-[![Open Issues](https://img.shields.io/github/issues/garylee909/Spotify-Downloader?label=Issues)](https://github.com/garylee909/Spotify-Downloader/issues?q=is%3Aissue+is%3Aopen)
-[![Closed Issues](https://img.shields.io/github/issues-closed/garylee909/Spotify-Downloader?label=Issues)](https://github.com/garylee909/Spotify-Downloader/issues?q=is%3Aissue+is%3Aclosed)
-[![Stars](https://img.shields.io/github/stars/garylee909/Spotify-Downloader?label=Stars&color=007ec6)](https://github.com/garylee909/Spotify-Downloader/stargazers)
+[![Latest Release](https://img.shields.io/github/v/release/WilliamSchack/Spotify-Downloader?label=Latest%20Release&color=007ec6)](https://github.com/WilliamSchack/Spotify-Downloader/releases)
+[![Downloads](https://img.shields.io/github/downloads/WilliamSchack/Spotify-Downloader/total?label=Downloads&color=007ec6)](https://github.com/WilliamSchack/Spotify-Downloader/releases)
+[![Open Issues](https://img.shields.io/github/issues/WilliamSchack/Spotify-Downloader?label=Issues)](https://github.com/WilliamSchack/Spotify-Downloader/issues?q=is%3Aissue+is%3Aopen)
+[![Closed Issues](https://img.shields.io/github/issues-closed/WilliamSchack/Spotify-Downloader?label=Issues)](https://github.com/WilliamSchack/Spotify-Downloader/issues?q=is%3Aissue+is%3Aclosed)
+[![Stars](https://img.shields.io/github/stars/WilliamSchack/Spotify-Downloader?label=Stars&color=007ec6)](https://github.com/WilliamSchack/Spotify-Downloader/stargazers)
 [![Ko-Fi](https://img.shields.io/badge/Support%20Development-FF5a16?style=flat&logo=Ko-fi&logoColor=FF5a16&label=ko-fi)](https://ko-fi.com/williamschack)
 
 Spotify Downloader is an application that allows you to easily download spotify playlists and songs through YouTube without the need of Spotify Premium through an easy to use GUI and many customisable settings to get the output that you desire.
 
 > [!IMPORTANT]
-> This repository contains an unofficial macOS port of
-> [WilliamSchack/Spotify-Downloader](https://github.com/WilliamSchack/Spotify-Downloader).
-> The macOS build is currently an Intel (`x86_64`) preview and is not signed
-> with an Apple Developer ID or notarized by Apple.
+> macOS support is currently experimental. The tested preview was built for
+> Intel (`x86_64`) and is not signed with an Apple Developer ID or notarized
+> by Apple.
 
 > [!CAUTION]
 > Note that users are responsible for any potential legal consequenses that comes with downloading music. I do not condone unauthorized downloading of copyrighted material and do not take any responsibility for user actions. I highly encourage you to purchase the songs directly from the artists to support them and their work
@@ -41,22 +40,19 @@ Spotify Downloader is an application that allows you to easily download spotify 
 ### macOS
 
 > [!WARNING]
-> The current preview build targets Intel Macs running macOS 26 or later.
-> Apple Silicon Macs require Rosetta 2. Wider macOS compatibility and a native
-> Apple Silicon build are not included in the current DMG.
+> No prebuilt macOS release is currently available. The preview has only been
+> tested on an Intel Mac running macOS 26. Other macOS versions and Apple
+> Silicon builds have not yet been verified.
 
-1. Open this repository's [Releases](https://github.com/garylee909/Spotify-Downloader/releases).
-2. Download `SpotifyDownloader-macOS.dmg` from the latest macOS release.
-3. Open the DMG and copy `SpotifyDownloader.app` to the `Applications` folder.
-4. Eject the DMG, then open Spotify Downloader from `Applications`.
-
-The app includes `ffmpeg`, `yt-dlp`, and QuickJS. Users installing the DMG do
-not need Homebrew, Anaconda, Qt, or a separate Python installation.
+Build and package the app from source by following
+[`docs/MACOS.md`](docs/MACOS.md). The packaging script creates a standalone
+app bundle and can optionally create `SpotifyDownloader-macOS.dmg`. Packaged
+builds include `ffmpeg`, `yt-dlp`, and QuickJS.
 
 #### First launch
 
-The preview is ad-hoc signed but not notarized. macOS may prevent a normal
-double-click launch:
+Locally packaged preview builds are ad-hoc signed but not notarized. macOS may
+prevent a normal double-click launch:
 
 1. In Finder, open `Applications`.
 2. Control-click or right-click `SpotifyDownloader.app`, then select **Open**.
@@ -64,28 +60,12 @@ double-click launch:
 4. If **Open** is not offered, go to **System Settings > Privacy & Security**,
    find the blocked Spotify Downloader message, and select **Open Anyway**.
 
-Only use a DMG downloaded from this repository's Releases page. A future
-Developer ID signed and notarized release will remove this extra first-launch
-step.
-
-#### Apple Silicon
-
-When prompted, allow macOS to install Rosetta 2. It can also be installed from
-Terminal:
-
-```sh
-softwareupdate --install-rosetta
-```
-
-Rosetta is an Apple compatibility component. It is only needed because the
-current preview is an Intel build.
+A future Developer ID signed and notarized release will remove this extra
+first-launch step.
 
 ### Windows
 
-The Windows packages and instructions below are maintained by the
-[upstream project](https://github.com/WilliamSchack/Spotify-Downloader).
-
-The latest upstream Windows release can be found
+The latest Windows release can be found
 [here](https://github.com/WilliamSchack/Spotify-Downloader/releases/latest).
 **For multiple use Installer Recommended, for single use Portable Recommended**
 
@@ -729,19 +709,17 @@ The next few updates will take a fair amount of work and time so figured I would
 
 Contributions to the macOS port are welcome.
 
-1. Fork this repository and create a branch from `macos-port`.
+1. Fork this repository and create a feature branch from the target branch.
 2. Follow the setup and build instructions in
    [`docs/MACOS.md`](docs/MACOS.md).
 3. Keep generated files out of Git. Do not commit `build/`, `*.app`, `*.dmg`,
    `Makefile`, object files, or generated Qt files.
 4. Build and test the app before opening a pull request.
-5. Open the pull request against this repository's `macos-port` branch and
-   include the Mac model, CPU architecture, macOS version, and test results.
+5. Include the Mac model, CPU architecture, macOS version, and test results in
+   the pull request.
 
-Changes that are not specific to the macOS port may be better contributed to
-the [upstream project](https://github.com/WilliamSchack/Spotify-Downloader).
 Please explain any cross-platform behavior changes clearly so they can be
-reviewed without breaking the upstream Windows build.
+reviewed without breaking the Windows build.
 
 ## License
 ***Spotify Downloader is distributed under the GNU General Public License v3.0 from 17/04/2024 and Release v1.1.3***

--- a/Spotify Downloader/Config.cpp
+++ b/Spotify Downloader/Config.cpp
@@ -84,13 +84,13 @@ void Config::LoadSettings() {
 
         // Get current metadata type bitrate
         QString codecBitrateKey = QString("audioBitrate%1").arg(Codec::Data[currentExtension].String.toUpper());
-        int audioBitrate = settings.value(codecBitrateKey, NULL).toInt();
+        QVariant audioBitrateValue = settings.value(codecBitrateKey);
 
         // If bitrate is not assigned, set to default
-        if (audioBitrate == NULL) {
+        if (!audioBitrateValue.isValid()) {
             // If MP3 is not assigned and bitrate was set in a previous version, set it to that
-            QVariant previousAudioBitrate = settings.value("audioBitrate", NULL);
-            if (currentExtension == Codec::Extension::MP3 && previousAudioBitrate != NULL) {
+            QVariant previousAudioBitrate = settings.value("audioBitrate");
+            if (currentExtension == Codec::Extension::MP3 && previousAudioBitrate.isValid()) {
                 AudioBitrate[currentExtension] = previousAudioBitrate.toInt();
 
                 // Remove previous value, not needed anymore
@@ -100,12 +100,12 @@ void Config::LoadSettings() {
             }
 
             // If previous bitrate is null, set to default
-            AudioBitrate[currentExtension] = Codec::Data[currentExtension].MaxBitrate;\
+            AudioBitrate[currentExtension] = Codec::Data[currentExtension].MaxBitrate;
             continue;
         }
 
         // Set bitrate
-        AudioBitrate[currentExtension] = audioBitrate;
+        AudioBitrate[currentExtension] = audioBitrateValue.toInt();
     }
 
     SaveLocation = settings.value("saveLocation", "").toString();
@@ -118,8 +118,8 @@ void Config::LoadSettings() {
     QString subFolders = settings.value("subFolders", "").toString();
 
     // Check if folder sorting index was set in previous version
-    QVariant previousFolderSortingIndex = settings.value("folderSortingIndex", NULL);
-    if (previousFolderSortingIndex != NULL) {
+    QVariant previousFolderSortingIndex = settings.value("folderSortingIndex");
+    if (previousFolderSortingIndex.isValid()) {
         // If it was set, assign new folder sorting to it
         int folderSortingIndex = previousFolderSortingIndex.toInt();
 

--- a/Spotify Downloader/Config.h
+++ b/Spotify Downloader/Config.h
@@ -15,6 +15,11 @@
 #include <QMap>
 #include <QIcon>
 #include <QMovie>
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QStringList>
 
 class Config {
     public:
@@ -27,9 +32,34 @@ class Config {
         static inline const QString ORGANIZATION_NAME = "WilliamSchack";
         static inline const QString APPLICATION_NAME = "Spotify Downloader";
 
+#if defined(Q_OS_WIN)
         static inline const QString YTDLP_PATH = "yt-dlp.exe";
         static inline const QString FFMPEG_PATH = "ffmpeg.exe";
         static inline const QString QUICKJS_PATH = "qjs.exe";
+#else
+        static inline const QString YTDLP_PATH = "yt-dlp";
+        static inline const QString FFMPEG_PATH = "ffmpeg";
+        static inline const QString QUICKJS_PATH = "qjs";
+#endif
+
+        static inline QString ExecutablePath(QString executableName) {
+            const QDir applicationDir(QCoreApplication::applicationDirPath());
+            const QStringList bundledPaths {
+                applicationDir.filePath(executableName),
+#if defined(Q_OS_MACOS)
+                applicationDir.filePath("../Resources/bin/" + executableName),
+                applicationDir.filePath("../Resources/" + executableName),
+#endif
+            };
+
+            for (const QString& bundledPath : bundledPaths) {
+                if (QFileInfo::exists(bundledPath))
+                    return QFileInfo(bundledPath).absoluteFilePath();
+            }
+
+            QString systemPath = QStandardPaths::findExecutable(executableName);
+            return systemPath.isEmpty() ? bundledPaths.first() : systemPath;
+        }
 
         static const int SETUP_SCREEN_INDEX = 0;
         static const int SETTINGS_SCREEN_INDEX = 1;

--- a/Spotify Downloader/Downloading/PlaylistDownloader.cpp
+++ b/Spotify Downloader/Downloading/PlaylistDownloader.cpp
@@ -366,7 +366,9 @@ bool PlaylistDownloader::DistributeTracks() {
 	}
 
 	// Get differences between current total and target total
-	QList<int> differenceInTracksPerThread = QList<int>(_threadCount);
+	QList<int> differenceInTracksPerThread;
+	for (int i = 0; i < _threadCount; i++)
+		differenceInTracksPerThread.append(0);
 
 	for (int i = 0; i < _threadCount; i++) {
 		SongDownloader* downloader = _threads[i]->Downloader;

--- a/Spotify Downloader/Downloading/Song.cpp
+++ b/Spotify Downloader/Downloading/Song.cpp
@@ -657,10 +657,10 @@ QString Song::Download(YTMusicAPI*& yt, QProcess*& process, bool overwrite, std:
 	// Download song
 	// Using --no-part because after killing mid-download, .part files stay in use and cant be deleted
 	// web client is currently not working, use default when no po token assigned (https://github.com/yt-dlp/yt-dlp/issues/12482)
-	process->setProgram(QCoreApplication::applicationDirPath() + "/" + _ytdlpPath);
+	process->setProgram(Config::ExecutablePath(_ytdlpPath));
 	QStringList ytdlpArgs;
-	ytdlpArgs << "--ffmpeg-location" << QCoreApplication::applicationDirPath() + "/" + _ffmpegPath;
-	ytdlpArgs << "--js-runtimes" << "quickjs:" + QCoreApplication::applicationDirPath() + "/" + _quickjsPath;
+	ytdlpArgs << "--ffmpeg-location" << Config::ExecutablePath(_ffmpegPath);
+	ytdlpArgs << "--js-runtimes" << "quickjs:" + Config::ExecutablePath(_quickjsPath);
 	ytdlpArgs << "-v";
 	ytdlpArgs << "--no-part";
 	ytdlpArgs << "--progress";
@@ -777,7 +777,7 @@ QString Song::Download(YTMusicAPI*& yt, QProcess*& process, bool overwrite, std:
 	
 	// Convert downloaded format to desired format
 	process = new QProcess();
-	QObject::connect(process, &QProcess::finished, process, &QProcess::deleteLater);
+	QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), process, &QProcess::deleteLater);
 	QObject::connect(process, &QProcess::readyRead, process, [&]() {
 		QString msProgressString = QString(process->readAll()).split("\n")[3].split("=")[1];
 		int msProgress = int(msProgressString.toInt() / 1000); // Remove last 3 digits
@@ -786,8 +786,8 @@ QString Song::Download(YTMusicAPI*& yt, QProcess*& process, bool overwrite, std:
 		onProgressUpdate(progress);
 	});
 
-	process->startCommand(QString(R"("%1" -i "%2" -progress - -nostats %3 %4 "%5")")
-		.arg(QCoreApplication::applicationDirPath() + "/" + _ffmpegPath)
+	process->start(QString(R"("%1" -i "%2" -progress - -nostats %3 %4 "%5")")
+		.arg(Config::ExecutablePath(_ffmpegPath))
 		.arg(downloadedPath)
 		.arg(Codec::Data[Codec].LockedBitrate ? "" : QString("-b:a %1k").arg(bitrate))
 		.arg(Codec::Data[Codec].FFMPEGConversionParams)
@@ -816,9 +816,9 @@ void Song::SetBitrate(QProcess*& process, int bitrate, std::function<void(float)
 
 	// Get duration for progress bar calculations
 	process = new QProcess();
-	QObject::connect(process, &QProcess::finished, process, &QProcess::deleteLater);
-	process->startCommand(QString(R"("%1" -i "%2" -f null -)")
-		.arg(QCoreApplication::applicationDirPath() + "/" + _ffmpegPath)
+	QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), process, &QProcess::deleteLater);
+	process->start(QString(R"("%1" -i "%2" -f null -)")
+		.arg(Config::ExecutablePath(_ffmpegPath))
 		.arg(_downloadingPath));
 	process->waitForFinished(-1);
 
@@ -828,7 +828,7 @@ void Song::SetBitrate(QProcess*& process, int bitrate, std::function<void(float)
 
 	// Set bitrate
 	process = new QProcess();
-	QObject::connect(process, &QProcess::finished, process, &QProcess::deleteLater);
+	QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), process, &QProcess::deleteLater);
 	QObject::connect(process, &QProcess::readyRead, process, [&]() {
 		QString msProgressString = QString(process->readAll()).split("\n")[3].split("=")[1];
 		int msProgress = int(msProgressString.toInt() / 1000); // Remove last 3 digits
@@ -838,8 +838,8 @@ void Song::SetBitrate(QProcess*& process, int bitrate, std::function<void(float)
 	});
 
 	QString newQualityFullPath = QString("%1/%2.%3").arg(_downloadingFolder).arg(FileName + "_A").arg(Codec::Data[Codec].String);
-	process->startCommand(QString(R"("%1" -i "%2" -progress - -nostats -b:a %3k "%4")")
-		.arg(QCoreApplication::applicationDirPath() + "/" + _ffmpegPath)
+	process->start(QString(R"("%1" -i "%2" -progress - -nostats -b:a %3k "%4")")
+		.arg(Config::ExecutablePath(_ffmpegPath))
 		.arg(_downloadingPath)
 		.arg(bitrate)
 		.arg(newQualityFullPath));
@@ -852,9 +852,9 @@ void Song::SetBitrate(QProcess*& process, int bitrate, std::function<void(float)
 void Song::NormaliseAudio(QProcess*& process, float normalisedAudioVolume, int bitrate, bool* quitting, std::function<void(float)> onProgressUpdate) {
 	// Get Audio Data
 	process = new QProcess();
-	QObject::connect(process, &QProcess::finished, process, &QProcess::deleteLater);
-	process->startCommand(QString(R"("%1" -i "%2" -af "volumedetect" -vn -sn -dn -f null -)")
-		.arg(QCoreApplication::applicationDirPath() + "/" + _ffmpegPath)
+	QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), process, &QProcess::deleteLater);
+	process->start(QString(R"("%1" -i "%2" -af "volumedetect" -vn -sn -dn -f null -)")
+		.arg(Config::ExecutablePath(_ffmpegPath))
 		.arg(_downloadingPath));
 	process->waitForFinished(-1);
 
@@ -881,7 +881,7 @@ void Song::NormaliseAudio(QProcess*& process, float normalisedAudioVolume, int b
 			}
 
 			process = new QProcess();
-			QObject::connect(process, &QProcess::finished, process, &QProcess::deleteLater);
+			QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), process, &QProcess::deleteLater);
 			QObject::connect(process, &QProcess::readyRead, process, [&]() {
 				QString progressS = process->readAll();
 
@@ -891,8 +891,8 @@ void Song::NormaliseAudio(QProcess*& process, float normalisedAudioVolume, int b
 
 				onProgressUpdate(progress);
 			});
-			process->startCommand(QString(R"("%1" -i "%2" -progress - -nostats %3 -af "volume=%4dB" "%5")")
-				.arg(QCoreApplication::applicationDirPath() + "/" + _ffmpegPath)
+			process->start(QString(R"("%1" -i "%2" -progress - -nostats %3 -af "volume=%4dB" "%5")")
+				.arg(Config::ExecutablePath(_ffmpegPath))
 				.arg(_downloadingPath)
 				.arg(Codec::Data[Codec].LockedBitrate ? "" : QString("-b:a %1k").arg(normaliseBitrate))
 				.arg(volumeApply)
@@ -975,7 +975,8 @@ void Song::AssignMetadata() {
 										.toUtf8().data();
 		TagLib::String commentText = "Thanks for using my program! :) - William S";
 
-		TagLib::String compressedComment = QString("%1\n%2\n%3").arg(copyrightText.toWString()).arg(publisherText.toWString()).arg(commentText.toWString()).toUtf8().data();
+		QString compressedCommentText = QString("%1\n%2\n%3").arg(QString::fromStdWString(copyrightText.toWString())).arg(QString::fromStdWString(publisherText.toWString())).arg(QString::fromStdWString(commentText.toWString()));
+		TagLib::String compressedComment(compressedCommentText.toUtf8().constData(), TagLib::String::UTF8);
 
 		TagLib::String releaseDate = QString("%1-%2-%3").arg(ReleaseDate.year()).arg(ReleaseDate.month()).arg(ReleaseDate.day()).toUtf8().data();
 		TagLib::String trackNumber = QString::number(TrackNumber()).toUtf8().data();

--- a/Spotify Downloader/Lyrics/Lyrics.cpp
+++ b/Spotify Downloader/Lyrics/Lyrics.cpp
@@ -23,13 +23,11 @@ std::string Lyrics::GetString() {
 				paddedSecondsStream << std::setw(2) << std::setfill('0') << seconds;
 				paddedHuntredthsStream << std::setw(2) << std::setfill('0') << hundredths;
 
-				std::string lyricTimestamped = std::format(
-					"[{}:{}.{}]{}\n",
-					paddedMinutesStream.str(),
-					paddedSecondsStream.str(),
-					paddedHuntredthsStream.str(),
-					lyric.Lyric
-				);
+				std::string lyricTimestamped =
+					"[" + paddedMinutesStream.str() +
+					":" + paddedSecondsStream.str() +
+					"." + paddedHuntredthsStream.str() +
+					"]" + lyric.Lyric + "\n";
 
 				lyricsString += lyricTimestamped;
 			}

--- a/Spotify Downloader/Lyrics/Lyrics.h
+++ b/Spotify Downloader/Lyrics/Lyrics.h
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <string>
 #include <list>
-#include <format>
 
 class Lyrics {
 	public:

--- a/Spotify Downloader/Network/MusixmatchAPI.cpp
+++ b/Spotify Downloader/Network/MusixmatchAPI.cpp
@@ -92,7 +92,7 @@ QString MusixmatchAPI::GenerateSignature(QString url) {
 	QByteArray urlEncodedHash = QUrl::toPercentEncoding(hashOutputBase64);
 
 	// Return the signature url params
-	return QString("&signature=%1&signature_protocol=sha256").arg(urlEncodedHash);
+	return QString("&signature=%1&signature_protocol=sha256").arg(QString::fromUtf8(urlEncodedHash));
 }
 
 QJsonObject MusixmatchAPI::Request(QString endpoint, QString isrc) {

--- a/Spotify Downloader/Network/SpotifyAuthInterceptor.cpp
+++ b/Spotify Downloader/Network/SpotifyAuthInterceptor.cpp
@@ -6,11 +6,13 @@ void SpotifyAuthInterceptor::interceptRequest(QWebEngineUrlRequestInfo &info)
         return;
 
     if (info.requestUrl().toString().contains("api-partner.spotify.com")) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         const QHash<QByteArray, QByteArray>& httpHeaders = info.httpHeaders();
         if (httpHeaders.contains("authorization") && Authorization.isEmpty())
-            Authorization = info.httpHeaders()["authorization"];
+            Authorization = httpHeaders["authorization"];
         if (httpHeaders.contains("client-token") && ClientToken.isEmpty())
-            ClientToken = info.httpHeaders()["client-token"];
+            ClientToken = httpHeaders["client-token"];
+#endif
     }
 
     // Cant get response body, get the url and do another request for the js

--- a/Spotify Downloader/Network/SpotifyAuthInterceptor.h
+++ b/Spotify Downloader/Network/SpotifyAuthInterceptor.h
@@ -1,7 +1,9 @@
 #ifndef SPOTIFYAUTHINTERCEPTOR_H
 #define SPOTIFYAUTHINTERCEPTOR_H
 
-#include <QtWebEngineCore>
+#include <QWebEngineUrlRequestInfo>
+#include <QWebEngineUrlRequestInterceptor>
+#include <QHash>
 
 class SpotifyAuthInterceptor : public QWebEngineUrlRequestInterceptor
 {

--- a/Spotify Downloader/Network/SpotifyAuthRetriever.h
+++ b/Spotify Downloader/Network/SpotifyAuthRetriever.h
@@ -7,7 +7,10 @@
 
 #include <QUrl>
 #include <QEventLoop>
-#include <QtWebEngineCore>
+#include <QRegularExpression>
+#include <QTimer>
+#include <QWebEnginePage>
+#include <QWebEngineProfile>
 
 #include <iostream>
 #include <regex>

--- a/Spotify Downloader/Network/YTMusicAPI.cpp
+++ b/Spotify Downloader/Network/YTMusicAPI.cpp
@@ -121,7 +121,10 @@ QJsonArray YTMusicAPI::Search(QString query, QString filter, int limit) {
 		} else if (result.contains("musicShelfRenderer")) {
 			contents = JSONUtils::Navigate(result, { "musicShelfRenderer", "contents" }).toArray();
 			category = JSONUtils::Navigate(result, { "musicShelfRenderer", "title", "runs", 0, "text" }).toString();
-			type = filter.removeLast().toLower();
+			type = filter;
+			if (!type.isEmpty())
+				type.chop(1);
+			type = type.toLower();
 		} else {
 			continue;
 		}
@@ -664,7 +667,7 @@ Lyrics YTMusicAPI::GetLyrics(QString videoId, bool timestamps) {
 
 		// Setup lyrics source message
 		Lyrics lyrics;
-		lyrics.SourceMessage = std::format("YouTube: {}", data["sourceMessage"].toString().split("Source: ")[1].toStdString());
+		lyrics.SourceMessage = QString("YouTube: %1").arg(data["sourceMessage"].toString().split("Source: ")[1]).toStdString();
 
 		// Get lyrics
 		QJsonArray timedLyricsData = data["timedLyricsData"].toArray();
@@ -693,7 +696,7 @@ Lyrics YTMusicAPI::GetLyrics(QString videoId, bool timestamps) {
 		if (unsyncedTimedLyrics) {
 			std::string unsyncedTimedLyricsString = "";
 			foreach(Lyrics::SynchronisedLyric syncedLyric, lyricsList) {
-				unsyncedTimedLyricsString += std::format("{}\n", syncedLyric.Lyric);
+				unsyncedTimedLyricsString += syncedLyric.Lyric + "\n";
 			}
 
 			lyrics.Type = Lyrics::LyricsType::Unsynced;

--- a/Spotify Downloader/Network/YTMusicAPI.h
+++ b/Spotify Downloader/Network/YTMusicAPI.h
@@ -14,7 +14,6 @@
 
 #include <time.h>
 #include <regex>
-#include <format>
 
 #include <QObject>
 #include <QTime>

--- a/Spotify Downloader/Playlist/PlaylistFile.cpp
+++ b/Spotify Downloader/Playlist/PlaylistFile.cpp
@@ -54,10 +54,10 @@ void PlaylistFile::CreatePlaylistFileFromTracks(QStringList trackFilePaths, QStr
 		PlaylistFileTrack track{
 			absolutePath,
 			encodedPath,
-			QString::fromUtf8(title),
-			QString::fromUtf8(artist),
-			QString::fromUtf8(album),
-			QString::fromUtf8(comment),
+			QString::fromStdString(title),
+			QString::fromStdString(artist),
+			QString::fromStdString(album),
+			QString::fromStdString(comment),
 			trackNum,
 			durationSeconds,
 			durationMilliseconds

--- a/Spotify Downloader/SpotifyDownloader.cpp
+++ b/Spotify Downloader/SpotifyDownloader.cpp
@@ -2,7 +2,9 @@
 
 #include <QMovie>
 
+#if defined(Q_OS_WIN)
 #include <qt_windows.h>
+#endif
 
 // Ui Setup
 SpotifyDownloader::SpotifyDownloader(QWidget* parent) : QDialog(parent)
@@ -177,6 +179,7 @@ void SpotifyDownloader::closeEvent(QCloseEvent* closeEvent) {
 }
 
 bool SpotifyDownloader::IsElevated() {
+#if defined(Q_OS_WIN)
     BOOL fRet = false;
     HANDLE hToken = NULL;
     if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
@@ -192,6 +195,9 @@ bool SpotifyDownloader::IsElevated() {
     }
 
     return fRet;
+#else
+    return false;
+#endif
 }
 
 // Application Exit

--- a/Spotify Downloader/UI/CustomWidgets/SongErrorItem.cpp
+++ b/Spotify Downloader/UI/CustomWidgets/SongErrorItem.cpp
@@ -1,5 +1,7 @@
 #include "SongErrorItem.h"
 
+#include <QUrl>
+
 SongErrorItem::SongErrorItem(QWidget* parent) : QWidget(parent) {
 	// Fonts
 	QFont font1 = QFont();
@@ -109,7 +111,7 @@ void SongErrorItem::AddLinkInput(QString searchQuery, const std::function<void(Q
 	searchButton->setIcon(QIcon(":/SpotifyDownloader/Icons/Search_Icon_B.png"));
 
 	QByteArray queryPercentEncoding = QUrl::toPercentEncoding(searchQuery);
-	QUrl searchUrl = QUrl(QString("https://music.youtube.com/search?q=%1").arg(queryPercentEncoding));
+	QUrl searchUrl = QUrl(QString("https://music.youtube.com/search?q=%1").arg(QString::fromUtf8(queryPercentEncoding)));
 	connect(searchButton, &QPushButton::clicked, [searchUrl] {
 		QDesktopServices::openUrl(searchUrl);
 	});

--- a/Spotify Downloader/UI/UISetup.cpp
+++ b/Spotify Downloader/UI/UISetup.cpp
@@ -406,7 +406,7 @@ void SpotifyDownloader::SetupSettingsScreen() {
     }
 
     // Set combo box variables on change
-    connect(_ui.CodecInput, &QComboBox::currentIndexChanged, [=](int index) {
+    connect(_ui.CodecInput, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
         // Set codec
         Config::SetCodecIndex(index);
 
@@ -442,7 +442,7 @@ void SpotifyDownloader::SetupSettingsScreen() {
         _ui.AudioBitrateFileSizeLabel_Value->setText(fileSizeText);
     });
 
-    connect(_ui.TrackNumberInput, &QComboBox::currentIndexChanged, [=](int index) {
+    connect(_ui.TrackNumberInput, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
         Config::TrackNumberIndex = index;
 
         // Update warning if set to playlist track number and line indicator height if changed
@@ -460,8 +460,8 @@ void SpotifyDownloader::SetupSettingsScreen() {
         }
     });
 
-    connect(_ui.PlaylistFileTypeInput, &QComboBox::currentIndexChanged, [=](int index) { Config::PlaylistFileTypeIndex = index; });
-    connect(_ui.DownloaderThreadUIInput, &QComboBox::currentIndexChanged, [=](int index) { Config::DownloaderThreadUIIndex = index; });
+    connect(_ui.PlaylistFileTypeInput, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) { Config::PlaylistFileTypeIndex = index; });
+    connect(_ui.DownloaderThreadUIInput, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) { Config::DownloaderThreadUIIndex = index; });
 
     // Update PO Token on text change
     connect(_ui.POTokenInput, &QLineEdit::textChanged, [=](QString text) { Config::POToken = text; });
@@ -1121,6 +1121,7 @@ bool SpotifyDownloader::ValidateDirectory() {
                 );
 
                 if (adminInput == QMessageBox::Yes) {
+#if defined(Q_OS_WIN)
                     // Restart with admin perms
                     QString exePath = QCoreApplication::applicationFilePath();
                     QStringList args = QStringList({ "-Command", QString("Start-Process '%1' -Verb runAs").arg(exePath) });
@@ -1130,6 +1131,15 @@ bool SpotifyDownloader::ValidateDirectory() {
                     // Wait for elevated process to open, then close this one
                     elevatedApplication->waitForFinished();
                     QCoreApplication::quit();
+#else
+                    ShowMessageBoxWithButtons(
+                        "Directory Error",
+                        "Automatic permission elevation is only available on Windows.\nPlease choose a writable folder.",
+                        QMessageBox::Critical,
+                        QMessageBox::Ok
+                    );
+                    return false;
+#endif
                 } else if (adminInput == QMessageBox::No) {
                     return false;
                 }

--- a/SpotifyDownloader.pro
+++ b/SpotifyDownloader.pro
@@ -1,0 +1,78 @@
+QT += core gui widgets network concurrent webenginecore webenginewidgets uitools
+
+CONFIG += c++17
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
+
+TEMPLATE = app
+TARGET = SpotifyDownloader
+
+APP_DIR = "$$PWD/Spotify Downloader"
+
+SOURCES += \
+    "$$APP_DIR/main.cpp" \
+    "$$APP_DIR/Application.cpp" \
+    "$$APP_DIR/Config.cpp" \
+    "$$APP_DIR/SpotifyDownloader.cpp" \
+    "$$APP_DIR/Downloading/PlaylistDownloader.cpp" \
+    "$$APP_DIR/Downloading/Song.cpp" \
+    "$$APP_DIR/Downloading/SongDownloader.cpp" \
+    "$$APP_DIR/Lyrics/LRCFile.cpp" \
+    "$$APP_DIR/Lyrics/Lyrics.cpp" \
+    "$$APP_DIR/Network/MusixmatchAPI.cpp" \
+    "$$APP_DIR/Network/Network.cpp" \
+    "$$APP_DIR/Network/Notices.cpp" \
+    "$$APP_DIR/Network/SpotifyAPI.cpp" \
+    "$$APP_DIR/Network/SpotifyAuthInterceptor.cpp" \
+    "$$APP_DIR/Network/SpotifyAuthRetriever.cpp" \
+    "$$APP_DIR/Network/VersionManager.cpp" \
+    "$$APP_DIR/Network/YTMusicAPI.cpp" \
+    "$$APP_DIR/Playlist/M3UFile.cpp" \
+    "$$APP_DIR/Playlist/PLSFile.cpp" \
+    "$$APP_DIR/Playlist/PlaylistFile.cpp" \
+    "$$APP_DIR/Playlist/XSPFFile.cpp" \
+    "$$APP_DIR/UI/UISetup.cpp" \
+    "$$APP_DIR/UI/UIUtilities.cpp" \
+    "$$APP_DIR/UI/CustomWidgets/CheckBox.cpp" \
+    "$$APP_DIR/UI/CustomWidgets/DownloaderThread.cpp" \
+    "$$APP_DIR/UI/CustomWidgets/NoticeItem.cpp" \
+    "$$APP_DIR/UI/CustomWidgets/SongErrorItem.cpp" \
+    "$$APP_DIR/Utilities/Animation.cpp" \
+    "$$APP_DIR/Utilities/FileUtils.cpp" \
+    "$$APP_DIR/Utilities/ImageUtils.cpp" \
+    "$$APP_DIR/Utilities/JSONUtils.cpp" \
+    "$$APP_DIR/Utilities/Logger.cpp" \
+    "$$APP_DIR/Utilities/MathUtils.cpp" \
+    "$$APP_DIR/Utilities/ObjectHoverWatcher.cpp" \
+    "$$APP_DIR/Utilities/StringUtils.cpp"
+
+HEADERS += \
+    "$$APP_DIR/Application.h" \
+    "$$APP_DIR/SpotifyDownloader.h" \
+    "$$APP_DIR/Network/SpotifyAuthInterceptor.h" \
+    "$$APP_DIR/UI/CustomWidgets/CheckBox.h" \
+    "$$APP_DIR/UI/CustomWidgets/DownloaderThread.h" \
+    "$$APP_DIR/UI/CustomWidgets/NoticeItem.h" \
+    "$$APP_DIR/UI/CustomWidgets/SongErrorItem.h" \
+    "$$APP_DIR/Utilities/ObjectHoverWatcher.h"
+
+FORMS += "$$APP_DIR/SpotifyDownloader.ui"
+RESOURCES += "$$APP_DIR/SpotifyDownloader.qrc"
+
+INCLUDEPATH += \
+    "$$APP_DIR" \
+    "$$APP_DIR/include" \
+    /usr/local/include
+
+macx {
+    QMAKE_LIBS_OPENGL = -framework OpenGL
+    LIBS += -L/usr/local/lib -ltag
+}
+
+unix:!macx {
+    LIBS += -ltag
+}
+
+win32 {
+    RC_FILE = "$$APP_DIR/SpotifyDownloader.rc"
+    LIBS += "$$APP_DIR/lib/tag.lib"
+}

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -110,7 +110,10 @@ On newer Xcode/macOS SDKs, Qt 5.15 may emit warnings about unsupported SDK versi
 
 ## Environment Hygiene
 
-The conda environment keeps the CLI tools isolated under `/Users/garylee/anaconda3/envs/spotify-downloader-macos` when created locally. Homebrew packages are installed globally under `/usr/local`; this is normal for Homebrew, but it is not isolated. For cleaner development, prefer one of these approaches:
+The conda environment keeps the CLI tools isolated under its own
+`$CONDA_PREFIX`. Homebrew packages are installed in the active Homebrew
+prefix; this is normal for Homebrew, but it is not isolated. For cleaner
+development, prefer one of these approaches:
 
 - Use GitHub Actions or a dedicated macOS VM for release builds.
 - Use a dedicated Homebrew prefix, CI runner, or separate user account for local macOS dependency experiments.

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,0 +1,120 @@
+# macOS Development Notes
+
+This document records the macOS porting state and the dependencies needed to build and run the app.
+
+## Current Status
+
+The app has two macOS build paths:
+
+- Recommended: Qt 6 + CMake
+- Temporary/local compatibility path: qmake from an Anaconda Qt 5.15 installation
+
+Qt 6 is the preferred path because the Spotify auth interceptor relies on `QWebEngineUrlRequestInfo::httpHeaders()`, which is available in Qt 6.
+
+## Dependencies
+
+Preferred isolated CLI/tooling environment:
+
+```sh
+conda env create -f environment-macos.yml
+conda activate spotify-downloader-macos
+```
+
+This installs:
+
+- `python=3.11`
+- `cmake`
+- `ninja`
+- `pkg-config`
+- `ffmpeg`
+- `yt-dlp`
+- `quickjs`
+- `pyinstaller`
+
+`environment-macos.yml` intentionally avoids the Anaconda base environment and keeps these tools under the dedicated `spotify-downloader-macos` env.
+
+Full Qt/TagLib development dependencies:
+
+```sh
+brew bundle
+```
+
+The included `Brewfile` installs the dependencies that are not fully covered by conda-forge on `osx-64`:
+
+- `taglib`
+- `ffmpeg`
+- `yt-dlp`
+- `quickjs`
+- `cmake`
+- `ninja`
+- `qt`
+- `pkg-config`
+
+Current conda-forge `osx-64` limitations checked locally:
+
+- No `taglib` package is available by that name.
+- `qt6-main` is available, but Qt 6 WebEngine is not available as `qt6-webengine`.
+- Qt 5 WebEngine is available as `qt-webengine`, but it does not provide the Qt 6 `QWebEngineUrlRequestInfo::httpHeaders()` API needed for full Spotify auth capture.
+
+For full Qt 6 functionality, prefer the official Qt 6 installer or a CI/Homebrew build that includes Qt WebEngine. For isolated local development, install Homebrew dependencies in a dedicated prefix, VM, CI runner, or separate user account rather than relying on a daily-use machine.
+
+## Build
+
+Recommended CMake flow:
+
+```sh
+cmake -S . -B build -G Ninja \
+  -DCMAKE_PREFIX_PATH="$(brew --prefix qt)" \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+Packaging flow:
+
+```sh
+conda activate spotify-downloader-macos
+QT_PREFIX="$HOME/Qt/6.x.x/macos" scripts/package-macos.sh
+```
+
+The packaging script:
+
+- Builds the app with CMake/Ninja.
+- Runs `macdeployqt`.
+- Copies `ffmpeg` and `qjs` from the active conda env or `PATH` into `SpotifyDownloader.app/Contents/Resources/bin`.
+- Builds `yt-dlp` into a standalone binary with PyInstaller when available, so the app bundle does not depend on the user's conda Python.
+- Ad-hoc signs the local app bundle by default; set `CODESIGN_IDENTITY` for Developer ID signing.
+- Optionally creates a dmg when `CREATE_DMG=1` is set.
+
+Examples:
+
+```sh
+QT_PREFIX="$HOME/Qt/6.x.x/macos" CREATE_DMG=1 scripts/package-macos.sh
+QT_PREFIX="$(brew --prefix qt)" CODESIGN_IDENTITY="Developer ID Application: Example" scripts/package-macos.sh
+```
+
+Temporary qmake flow:
+
+```sh
+qmake SpotifyDownloader.pro
+make -j4
+macdeployqt SpotifyDownloader.app
+```
+
+On newer Xcode/macOS SDKs, Qt 5.15 may emit warnings about unsupported SDK versions. The local Anaconda Qt 5.15 mkspec can also inject the removed `AGL.framework`; if this happens, remove `-framework AGL` from the generated `Makefile` before linking, or use the Qt 6 CMake path.
+
+## Known Limitations
+
+- The Qt 5 compatibility path cannot read Spotify auth request headers because `QWebEngineUrlRequestInfo::httpHeaders()` is a Qt 6 API. Use Qt 6 for full functionality.
+- The app bundle produced by `macdeployqt` may need extra Qt WebEngine resources when using non-standard Qt layouts such as Anaconda Qt.
+- Homebrew's TagLib bottle may target a newer macOS version than an older deployment target. This is fine for local development, but release builds should align the deployment target and dependency builds.
+
+## Environment Hygiene
+
+The conda environment keeps the CLI tools isolated under `/Users/garylee/anaconda3/envs/spotify-downloader-macos` when created locally. Homebrew packages are installed globally under `/usr/local`; this is normal for Homebrew, but it is not isolated. For cleaner development, prefer one of these approaches:
+
+- Use GitHub Actions or a dedicated macOS VM for release builds.
+- Use a dedicated Homebrew prefix, CI runner, or separate user account for local macOS dependency experiments.
+- Use `environment-macos.yml` for the tools that conda can manage cleanly.
+- Prefer the CMake build so dependency discovery is explicit and reproducible.
+
+Do not commit generated qmake or build artifacts such as `Makefile`, `*.o`, `moc_*.cpp`, `qrc_*.cpp`, `ui_*.h`, or `SpotifyDownloader.app`.

--- a/environment-macos.yml
+++ b/environment-macos.yml
@@ -1,0 +1,23 @@
+name: spotify-downloader-macos
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - cmake
+  - ninja
+  - pkg-config
+  - ffmpeg
+  - yt-dlp
+  - quickjs
+  - pyinstaller
+
+# Notes:
+# - This environment intentionally keeps CLI/runtime tools isolated from
+#   Homebrew and the Anaconda base environment.
+# - PyInstaller is used during packaging to produce a standalone yt-dlp binary
+#   for the macOS app bundle.
+# - conda-forge osx-64 currently does not provide TagLib as `taglib`.
+# - conda-forge osx-64 provides `qt6-main`, but not Qt 6 WebEngine. For the
+#   full Spotify auth path, use the official Qt 6 installer or another Qt 6
+#   distribution that includes WebEngine.

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-"$ROOT_DIR/build-macos"}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+APP_PATH="$BUILD_DIR/SpotifyDownloader.app"
+TOOLS_DIR="$APP_PATH/Contents/Resources/bin"
+TOOLS_LIB_DIR="$APP_PATH/Contents/Resources/lib"
+DMG_PATH="${DMG_PATH:-"$BUILD_DIR/SpotifyDownloader-macOS.dmg"}"
+
+QT_PREFIX="${QT_PREFIX:-${CMAKE_PREFIX_PATH:-}}"
+if [[ -z "$QT_PREFIX" ]] && command -v brew >/dev/null 2>&1; then
+    QT_PREFIX="$(brew --prefix qt 2>/dev/null || true)"
+fi
+
+if [[ -z "$QT_PREFIX" || ! -d "$QT_PREFIX" ]]; then
+    echo "QT_PREFIX or CMAKE_PREFIX_PATH must point to a Qt 6 installation with WebEngine." >&2
+    echo "Example: QT_PREFIX=\"\$HOME/Qt/6.8.2/macos\" $0" >&2
+    exit 1
+fi
+
+MACDEPLOYQT="${MACDEPLOYQT:-"$QT_PREFIX/bin/macdeployqt"}"
+if [[ ! -x "$MACDEPLOYQT" && -x "/usr/local/opt/qtbase/bin/macdeployqt" ]]; then
+    MACDEPLOYQT="/usr/local/opt/qtbase/bin/macdeployqt"
+fi
+if [[ ! -x "$MACDEPLOYQT" ]]; then
+    MACDEPLOYQT="$(command -v macdeployqt || true)"
+fi
+
+if [[ -z "$MACDEPLOYQT" || ! -x "$MACDEPLOYQT" ]]; then
+    echo "macdeployqt was not found. Check QT_PREFIX or set MACDEPLOYQT." >&2
+    exit 1
+fi
+
+tool_path() {
+    local name="$1"
+
+    if [[ -n "${CONDA_PREFIX:-}" && -x "$CONDA_PREFIX/bin/$name" ]]; then
+        printf '%s\n' "$CONDA_PREFIX/bin/$name"
+        return
+    fi
+
+    command -v "$name" || true
+}
+
+copy_tool() {
+    local name="$1"
+    local source
+
+    if [[ "$name" == "yt-dlp" ]] && command -v python >/dev/null 2>&1 && python -m PyInstaller --version >/dev/null 2>&1; then
+        build_standalone_ytdlp
+        return
+    fi
+
+    source="$(tool_path "$name")"
+    if [[ -z "$source" || ! -x "$source" ]]; then
+        echo "Required tool '$name' was not found. Activate the conda env or set PATH." >&2
+        exit 1
+    fi
+
+    install -m 755 "$source" "$TOOLS_DIR/$name"
+}
+
+build_standalone_ytdlp() {
+    local pyinstaller_dir="$BUILD_DIR/tools/pyinstaller"
+    local dist_dir="$BUILD_DIR/tools/dist"
+    local launcher="$BUILD_DIR/tools/yt_dlp_launcher.py"
+
+    mkdir -p "$BUILD_DIR/tools" "$dist_dir" "$pyinstaller_dir"
+
+    cat > "$launcher" <<'PY'
+from yt_dlp import main
+
+if __name__ == "__main__":
+    main()
+PY
+
+    PYINSTALLER_CONFIG_DIR="$BUILD_DIR/tools/pyinstaller-config" python -m PyInstaller \
+        --onedir \
+        --clean \
+        --name yt-dlp \
+        --distpath "$dist_dir" \
+        --workpath "$pyinstaller_dir" \
+        --specpath "$BUILD_DIR/tools" \
+        "$launcher"
+
+    install -m 755 "$dist_dir/yt-dlp/yt-dlp" "$TOOLS_DIR/yt-dlp"
+    ditto "$dist_dir/yt-dlp/_internal" "$TOOLS_DIR/_internal"
+}
+
+bundle_conda_dylibs_for() {
+    local executable="$1"
+
+    if [[ -z "${CONDA_PREFIX:-}" || ! -d "$CONDA_PREFIX/lib" ]]; then
+        return
+    fi
+
+    mkdir -p "$TOOLS_LIB_DIR"
+
+    local queue=("$executable")
+    local seen=" "
+    local current dep base source target
+
+    while ((${#queue[@]})); do
+        current="${queue[0]}"
+        queue=("${queue[@]:1}")
+
+        [[ -f "$current" ]] || continue
+
+        while IFS= read -r dep; do
+            base="$(basename "$dep")"
+            source=""
+
+            if [[ "$dep" == @rpath/* && -f "$CONDA_PREFIX/lib/$base" ]]; then
+                source="$CONDA_PREFIX/lib/$base"
+            elif [[ "$dep" == "$CONDA_PREFIX/lib/"* && -f "$dep" ]]; then
+                source="$dep"
+                install_name_tool -change "$dep" "@rpath/$base" "$current" 2>/dev/null || true
+            fi
+
+            [[ -n "$source" ]] || continue
+
+            target="$TOOLS_LIB_DIR/$base"
+            if [[ ! -f "$target" ]]; then
+                install -m 755 "$source" "$target"
+                install_name_tool -id "@rpath/$base" "$target" 2>/dev/null || true
+            fi
+
+            if [[ "$seen" != *" $target "* ]]; then
+                seen="$seen$target "
+                queue+=("$target")
+            fi
+        done < <(otool -L "$current" 2>/dev/null | awk 'NR > 1 { print $1 }')
+    done
+}
+
+cmake_prefixes=("$QT_PREFIX")
+macdeployqt_args=("$APP_PATH" "-verbose=1" "-always-overwrite")
+if command -v brew >/dev/null 2>&1; then
+    while IFS= read -r formula; do
+        prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
+        if [[ -d "$prefix/lib/cmake" ]]; then
+            cmake_prefixes+=("$prefix")
+        fi
+        if [[ -d "$prefix/lib" ]]; then
+            macdeployqt_args+=("-libpath=$prefix/lib")
+        fi
+    done < <(brew list --formula | grep '^qt' || true)
+
+    for formula in brotli webp zstd dbus graphite2 harfbuzz fontconfig taglib; do
+        prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
+        if [[ -d "$prefix/lib" ]]; then
+            macdeployqt_args+=("-libpath=$prefix/lib")
+        fi
+    done
+fi
+
+CMAKE_PREFIX_JOINED="$(IFS=';'; printf '%s' "${cmake_prefixes[*]}")"
+
+cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -G Ninja \
+    -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_JOINED" \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+cmake --build "$BUILD_DIR" --config "$BUILD_TYPE"
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "Expected app bundle was not created: $APP_PATH" >&2
+    exit 1
+fi
+
+mkdir -p "$TOOLS_DIR"
+copy_tool ffmpeg
+copy_tool yt-dlp
+copy_tool qjs
+
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+    macdeployqt_args+=("-codesign=$CODESIGN_IDENTITY")
+else
+    macdeployqt_args+=("-no-codesign")
+fi
+
+macdeployqt_args+=("-executable=$TOOLS_DIR/ffmpeg")
+macdeployqt_args+=("-executable=$TOOLS_DIR/qjs")
+
+if [[ -n "${CONDA_PREFIX:-}" && -d "$CONDA_PREFIX/lib" ]]; then
+    macdeployqt_args+=("-libpath=$CONDA_PREFIX/lib")
+fi
+
+"$MACDEPLOYQT" "${macdeployqt_args[@]}"
+
+bundle_conda_dylibs_for "$TOOLS_DIR/ffmpeg"
+bundle_conda_dylibs_for "$TOOLS_DIR/qjs"
+
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+    codesign --force --deep --options runtime --sign "$CODESIGN_IDENTITY" "$APP_PATH"
+else
+    codesign --force --deep --sign - "$APP_PATH"
+fi
+
+if [[ "${CREATE_DMG:-0}" == "1" ]]; then
+    rm -f "$DMG_PATH"
+    hdiutil create -volname "Spotify Downloader" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_PATH"
+    echo "Created $DMG_PATH"
+else
+    echo "Created $APP_PATH"
+fi


### PR DESCRIPTION
## Summary

This PR adds an experimental macOS port of Spotify Downloader using Qt 6 and CMake.

## Changes

- Added Qt 6/CMake build support
- Added macOS compatibility fixes
- Restored Spotify authentication header capture using Qt 6 WebEngine
- Added macOS app and DMG packaging script
- Bundled ffmpeg, yt-dlp, and QuickJS with the app
- Added a GitHub Actions macOS build workflow
- Added isolated Conda environment and Homebrew dependency definitions
- Added macOS installation, usage, build, and contribution documentation
- Preserved the existing Windows implementation

## Tested

- Intel Mac (`x86_64`)
- macOS 26
- Qt 6.11 with Qt WebEngine
- ffmpeg 8.1.1
- yt-dlp 2026.06.09
- QuickJS 2025-09-13

The generated app bundle, bundled command-line tools, code signature, and DMG checksum were verified locally.

## Current limitations

- The current build is Intel-only
- Apple Silicon requires Rosetta 2
- The app is ad-hoc signed and not Apple-notarized
- Wider macOS version compatibility has not yet been tested
- Release binaries are distributed through GitHub Releases rather than committed to Git

## Credits

Original application by William Schack.

macOS port developed by Gary Lee in collaboration with OpenAI Codex.